### PR TITLE
Fix #20 for pown_rev with positive p. Use util::mpfr_root_si .

### DIFF
--- a/p1788/flavor/infsup/setbased/mpfr_bin_ieee754_flavor.hpp
+++ b/p1788/flavor/infsup/setbased/mpfr_bin_ieee754_flavor.hpp
@@ -2747,17 +2747,6 @@ public:
     template<typename T_>
     static representation_dec abs_rev(representation_dec_type<T_> const& c);
 
-
-private:
-    static int pown_rev_inf(mpfr_var const& c,
-                            mpfr_var& x,
-                            int p);
-    static int pown_rev_sup(mpfr_var const& c,
-                            mpfr_var& x,
-                            int p);
-
-public:
-
     /// \todo TODO
     ///
     ///

--- a/p1788/util/mpfr_var.hpp
+++ b/p1788/util/mpfr_var.hpp
@@ -116,6 +116,18 @@ private:
 // and −0 for k nonnegative, whatever the parity of k.
 int mpfr_root_si(mpfr_ptr rop, mpfr_srcptr op, long int k, mpfr_rnd_t rnd);
 
+// Set k to the integer part of the division of x by Pi/2
+// the result is exact
+void mpfr_quadrant (mpz_ptr k, mpfr_srcptr op);
+
+// Set rop to (-1)^npi * asin(op) + npi*pi
+int mpfr_asin_npi(mpfr_ptr rop, mpfr_srcptr op, mpz_t npi, mpfr_rnd_t rnd);
+
+// Set rop to (-1)^npi * acos(op) + (npi + (1 - (-1)^npi)/2)*pi
+int mpfr_acos_npi(mpfr_ptr rop, mpfr_srcptr op, mpz_t npi, mpfr_rnd_t rnd);
+
+// Set rop to atan(op) + npi*pi
+int mpfr_atan_npi(mpfr_ptr rop, mpfr_srcptr op, mpz_t npi, mpfr_rnd_t rnd);
 
 } // namespace util
 

--- a/p1788/util/mpfr_var.hpp
+++ b/p1788/util/mpfr_var.hpp
@@ -108,6 +108,14 @@ private:
 
 };
 
+// Possible MPFR extensions
+
+// Set rop to the kth root of op rounded in the direction rnd.
+// For k odd (resp. even) and op negative (including −Inf), set rop to a negative number (resp. NaN).
+// The kth root of −0 is defined to be -inf for negative odd k, NaN for negative even k
+// and −0 for k nonnegative, whatever the parity of k.
+int mpfr_root_si(mpfr_ptr rop, mpfr_srcptr op, long int k, mpfr_rnd_t rnd);
+
 
 } // namespace util
 

--- a/test/p1788/flavor/infsup/setbased/test_mpfr_bin_ieee754_flavor_rev_func.cpp
+++ b/test/p1788/flavor/infsup/setbased/test_mpfr_bin_ieee754_flavor_rev_func.cpp
@@ -1101,7 +1101,7 @@ BOOST_AUTO_TEST_CASE(minimal_sin_rev_bin_test)
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(0.0,0.0), REP<double>(-1.0,1.0)), REP<double>(0.0,0.0) );
     BOOST_CHECK( F<double>::is_empty( F<double>::sin_rev(REP<double>(-0.0,-0.0), REP<double>(2.0,2.5)) ) );
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(-0.0,-0.0), REP<double>(3.0,3.5)), REP<double>(std::stod("0x1.921fb54442d18p+1"),std::stod("0x1.921fb54442d19p+1")) );
-    BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(std::stod("0X1.FFFFFFFFFFFFFP-1"),std::stod("0X1P+0")), REP<double>(1.57,1.58 )), REP<double>(std::stod("0x1.921fb50442d18p+0"),std::stod("0x1.921fb58442d1ap+0")) );
+    BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(std::stod("0X1.FFFFFFFFFFFFFP-1"),std::stod("0X1P+0")), REP<double>(1.57,1.58 )), REP<double>(std::stod("0x1.921fb50442d18p+0"),std::stod("0x1.921fb58442d19p+0")) );
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(0.0,std::stod("0X1P+0")), REP<double>(-0.1,1.58)), REP<double>(0.0,1.58) );
 
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53")), REP<double>(3.14,3.15)), REP<double>(std::stod("0X1.921FB54442D17P+1"),std::stod("0X1.921FB54442D19P+1")) );
@@ -1215,7 +1215,7 @@ BOOST_AUTO_TEST_CASE(minimal_sin_rev_dec_bin_test)
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(0.0,0.0),DEC::dac), REP_DEC<double>(REP<double>(-1.0,1.0),DEC::def)), REP_DEC<double>(REP<double>(0.0,0.0),DEC::trv) );
     BOOST_CHECK( F<double>::is_empty( F<double>::sin_rev(REP_DEC<double>(REP<double>(-0.0,-0.0),DEC::def), REP_DEC<double>(REP<double>(2.0,2.5),DEC::trv)) ) );
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(-0.0,-0.0),DEC::def), REP_DEC<double>(REP<double>(3.0,3.5),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0x1.921fb54442d18p+1"),std::stod("0x1.921fb54442d19p+1")),DEC::trv) );
-    BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(std::stod("0X1.FFFFFFFFFFFFFP-1"),std::stod("0X1P+0")),DEC::dac), REP_DEC<double>(REP<double>(1.57,1.58),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0x1.921fb50442d18p+0"),std::stod("0x1.921fb58442d1ap+0")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(std::stod("0X1.FFFFFFFFFFFFFP-1"),std::stod("0X1P+0")),DEC::dac), REP_DEC<double>(REP<double>(1.57,1.58),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0x1.921fb50442d18p+0"),std::stod("0x1.921fb58442d19p+0")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(0.0,std::stod("0X1P+0")),DEC::com), REP_DEC<double>(REP<double>(-0.1,1.58),DEC::dac)), REP_DEC<double>(REP<double>(0.0,1.58),DEC::trv) );
 
     BOOST_CHECK_EQUAL( F<double>::sin_rev(REP_DEC<double>(REP<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53")),DEC::com), REP_DEC<double>(REP<double>(3.14,3.15),DEC::def)), REP_DEC<double>(REP<double>(std::stod("0X1.921FB54442D17P+1"),std::stod("0X1.921FB54442D19P+1")),DEC::trv) );
@@ -1328,7 +1328,7 @@ BOOST_AUTO_TEST_CASE(minimal_cos_rev_bin_test)
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(-1.0,1.0), REP<double>(-1.2,12.1)), REP<double>(-1.2,12.1) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(1.0,1.0), REP<double>(-0.1,0.1) ), REP<double>(0.0,0.0) );
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(-1.0,-1.0), REP<double>(3.14,3.15)), REP<double>(std::stod("0x1.921fb54442d17p+1"),std::stod("0x1.921fb54442d1ap+1")) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(-1.0,-1.0), REP<double>(3.14,3.15)), REP<double>(std::stod("0x1.921fb54442d18p+1"),std::stod("0x1.921fb54442d19p+1")) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("0X1.1A62633145C06P-54"),std::stod("0X1.1A62633145C07P-54")), REP<double>(1.57,1.58) ), REP<double>(std::stod("0X1.921FB54442D17P+0"),std::stod("0X1.921FB54442D19P+0")) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1.72CECE675D1FDP-53"),std::stod("-0X1.72CECE675D1FCP-53")), REP<double>(1.57,1.58) ), REP<double>(std::stod("0X1.921FB54442D18P+0"),std::stod("0X1.921FB54442D1AP+0")) );
@@ -1337,8 +1337,8 @@ BOOST_AUTO_TEST_CASE(minimal_cos_rev_bin_test)
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("0X1.1A62633145C06P-54"),1.0), REP<double>(0.0,2.0) ), REP<double>(0.0,std::stod("0X1.921FB54442D19P+0")) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1.72CECE675D1FDP-53"),1.0), REP<double>(-0.1,1.5708) ), REP<double>(-0.1,std::stod("0X1.921FB54442D1aP+0")) );
 
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), REP<double>(3.14,3.15) ), REP<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d1ap+1")) );
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), REP<double>(-3.15,-3.14) ), REP<double>(std::stod("-0x1.921fb56442d1ap+1"),std::stod("-0x1.921fb52442d18p+1")) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), REP<double>(3.14,3.15) ), REP<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d19p+1")) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), REP<double>(-3.15,-3.14) ), REP<double>(std::stod("-0x1.921fb56442d19p+1"),std::stod("-0x1.921fb52442d18p+1")) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), REP<double>(9.42,9.45) ), REP<double>(std::stod("0x1.2d97c7eb321d2p+3"),std::stod("0x1.2d97c7fb321d3p+3")) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP<double>(std::stod("0X1.87996529F9D92P-1"),1.0), REP<double>(-1.0,0.1) ), REP<double>(std::stod("-0x1.6666666666667p-1"),0.1) );
@@ -1445,7 +1445,7 @@ BOOST_AUTO_TEST_CASE(minimal_cos_rev_dec_bin_test)
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(-1.0,1.0),DEC::dac), REP_DEC<double>(REP<double>(-1.2,12.1),DEC::def)), REP_DEC<double>(REP<double>(-1.2,12.1),DEC::trv) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(1.0,1.0),DEC::def), REP_DEC<double>(REP<double>(-0.1,0.1),DEC::dac) ), REP_DEC<double>(REP<double>(0.0,0.0),DEC::trv) );
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(-1.0,-1.0),DEC::com), REP_DEC<double>(REP<double>(3.14,3.15),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0x1.921fb54442d17p+1"),std::stod("0x1.921fb54442d1ap+1")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(-1.0,-1.0),DEC::com), REP_DEC<double>(REP<double>(3.14,3.15),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0x1.921fb54442d18p+1"),std::stod("0x1.921fb54442d19p+1")),DEC::trv) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("0X1.1A62633145C06P-54"),std::stod("0X1.1A62633145C07P-54")),DEC::def), REP_DEC<double>(REP<double>(1.57,1.58),DEC::def) ), REP_DEC<double>(REP<double>(std::stod("0X1.921FB54442D17P+0"),std::stod("0X1.921FB54442D19P+0")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1.72CECE675D1FDP-53"),std::stod("-0X1.72CECE675D1FCP-53")),DEC::dac), REP_DEC<double>(REP<double>(1.57,1.58),DEC::dac) ), REP_DEC<double>(REP<double>(std::stod("0X1.921FB54442D18P+0"),std::stod("0X1.921FB54442D1AP+0")),DEC::trv) );
@@ -1454,8 +1454,8 @@ BOOST_AUTO_TEST_CASE(minimal_cos_rev_dec_bin_test)
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("0X1.1A62633145C06P-54"),1.0),DEC::dac), REP_DEC<double>(REP<double>(0.0,2.0),DEC::def) ), REP_DEC<double>(REP<double>(0.0,std::stod("0X1.921FB54442D19P+0")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1.72CECE675D1FDP-53"),1.0),DEC::def), REP_DEC<double>(REP<double>(-0.1,1.5708),DEC::dac) ), REP_DEC<double>(REP<double>(-0.1,std::stod("0X1.921FB54442D1aP+0")),DEC::trv) );
 
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")),DEC::dac), REP_DEC<double>(REP<double>(3.14,3.15),DEC::def) ), REP_DEC<double>(REP<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d1ap+1")),DEC::trv) );
-    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")),DEC::def), REP_DEC<double>(REP<double>(-3.15,-3.14),DEC::com) ), REP_DEC<double>(REP<double>(std::stod("-0x1.921fb56442d1ap+1"),std::stod("-0x1.921fb52442d18p+1")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")),DEC::dac), REP_DEC<double>(REP<double>(3.14,3.15),DEC::def) ), REP_DEC<double>(REP<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d19p+1")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")),DEC::def), REP_DEC<double>(REP<double>(-3.15,-3.14),DEC::com) ), REP_DEC<double>(REP<double>(std::stod("-0x1.921fb56442d19p+1"),std::stod("-0x1.921fb52442d18p+1")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")),DEC::def), REP_DEC<double>(REP<double>(9.42,9.45),DEC::dac) ), REP_DEC<double>(REP<double>(std::stod("0x1.2d97c7eb321d2p+3"),std::stod("0x1.2d97c7fb321d3p+3")),DEC::trv) );
 
     BOOST_CHECK_EQUAL( F<double>::cos_rev(REP_DEC<double>(REP<double>(std::stod("0X1.87996529F9D92P-1"),1.0),DEC::dac), REP_DEC<double>(REP<double>(-1.0,0.1),DEC::def) ), REP_DEC<double>(REP<double>(std::stod("-0x1.6666666666667p-1"),0.1),DEC::trv) );
@@ -1555,9 +1555,9 @@ BOOST_AUTO_TEST_CASE(minimal_tan_rev_bin_test)
     BOOST_CHECK_EQUAL( F<double>::tan_rev(F<double>::entire(), REP<double>(-1.5708,1.5708)), REP<double>(-1.5708,1.5708) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(0.0,0.0), REP<double>(-1.5708,1.5708)), REP<double>(0.0,0.0) );
 
-    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53")), REP<double>(-1.5708,1.5708)), REP<double>(std::stod("-0x1.921fb54442d1bp+0"),std::stod("0x1.921fb54442d19p+0")) );
+    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53")), REP<double>(-1.5708,1.5708)), REP<double>(std::stod("-0x1.921fb54442d19p+0"),std::stod("0x1.921fb54442d19p+0")) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("-0X1.1A62633145C07P-53"),std::stod("-0X1.1A62633145C06P-53")), REP<double>(3.14,3.15)), REP<double>(std::stod("0X1.921FB54442D17P+1"),std::stod("0X1.921FB54442D19P+1")) );
-    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")), REP<double>(-3.15,3.15)), REP<double>(std::stod("-0X1.921FB54442D19P+1"),std::stod("0X1.921FB54442D1aP+1")) );
+    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")), REP<double>(-3.15,3.15)), REP<double>(std::stod("-0X1.921FB54442D18P+1"),std::stod("0X1.921FB54442D1aP+1")) );
 
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53")), REP<double>(-INF_D,1.5707965)), REP<double>(-INF_D,std::stod("0x1.111858f8568f7p+0")) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53")), REP<double>(-1.5707965,INF_D)), REP<double>(std::stod("-0x1.111858f8568f7p+0"),INF_D) );
@@ -1651,9 +1651,9 @@ BOOST_AUTO_TEST_CASE(minimal_tan_rev_dec_bin_test)
     BOOST_CHECK_EQUAL( F<double>::tan_rev(F<double>::entire_dec(), REP_DEC<double>(REP<double>(-1.5708,1.5708),DEC::dac)), REP_DEC<double>(REP<double>(-1.5708,1.5708),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(0.0,0.0),DEC::com), REP_DEC<double>(REP<double>(-1.5708,1.5708),DEC::def)), REP_DEC<double>(REP<double>(0.0,0.0),DEC::trv) );
 
-    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53")),DEC::dac), REP_DEC<double>(REP<double>(-1.5708,1.5708),DEC::def)), REP_DEC<double>(REP<double>(std::stod("-0x1.921fb54442d1bp+0"),std::stod("0x1.921fb54442d19p+0")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53")),DEC::dac), REP_DEC<double>(REP<double>(-1.5708,1.5708),DEC::def)), REP_DEC<double>(REP<double>(std::stod("-0x1.921fb54442d19p+0"),std::stod("0x1.921fb54442d19p+0")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("-0X1.1A62633145C07P-53"),std::stod("-0X1.1A62633145C06P-53")),DEC::def), REP_DEC<double>(REP<double>(3.14,3.15),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("0X1.921FB54442D17P+1"),std::stod("0X1.921FB54442D19P+1")),DEC::trv) );
-    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")),DEC::com), REP_DEC<double>(REP<double>(-3.15,3.15),DEC::com)), REP_DEC<double>(REP<double>(std::stod("-0X1.921FB54442D19P+1"),std::stod("0X1.921FB54442D1aP+1")),DEC::trv) );
+    BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")),DEC::com), REP_DEC<double>(REP<double>(-3.15,3.15),DEC::com)), REP_DEC<double>(REP<double>(std::stod("-0X1.921FB54442D18P+1"),std::stod("0X1.921FB54442D1aP+1")),DEC::trv) );
 
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53")),DEC::def), REP_DEC<double>(REP<double>(-INF_D,1.5707965),DEC::def)), REP_DEC<double>(REP<double>(-INF_D,std::stod("0x1.111858f8568f7p+0")),DEC::trv) );
     BOOST_CHECK_EQUAL( F<double>::tan_rev(REP_DEC<double>(REP<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53")),DEC::com), REP_DEC<double>(REP<double>(-1.5707965,INF_D),DEC::dac)), REP_DEC<double>(REP<double>(std::stod("-0x1.111858f8568f7p+0"),INF_D),DEC::trv) );

--- a/test/p1788/infsup/test_integration_mpfr_bin_ieee754_flavor_rev.cpp
+++ b/test/p1788/infsup/test_integration_mpfr_bin_ieee754_flavor_rev.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(integration_cos_rev_test)
     BOOST_CHECK_EQUAL( I<float>::cos_rev(I<double>(1.0,1.0)), I<float>(-INF_F,INF_F) );
 
     BOOST_CHECK_EQUAL( cos_rev(I<double>(std::stod("0X1.1A62633145C06P-54"),std::stod("0X1.1A62633145C07P-54")), I<double>(1.57,1.58)), I<double>(std::stod("0X1.921FB54442D17P+0"),std::stod("0X1.921FB54442D19P+0")) );
-    BOOST_CHECK_EQUAL( I<double>::cos_rev(I<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), I<double>(3.14,3.15)), I<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d1ap+1")) );
+    BOOST_CHECK_EQUAL( I<double>::cos_rev(I<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1")), I<double>(3.14,3.15)), I<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d19p+1")) );
     BOOST_CHECK_EQUAL( I<float>::cos_rev(I<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53")), I<double>(-INF_D,1.5)), I<float>(-INF_F,std::stof("-0X1.921FB4P+0")) );
 
     BOOST_CHECK_EQUAL( cos_rev(DI<double>(-1.0,1.0,DEC::com)), DI<double>(-INF_D, INF_D,DEC::trv) );
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(integration_cos_rev_test)
 
     BOOST_CHECK_EQUAL( cos_rev(DI<double>(std::stod("0X1.1A62633145C06P-54"),std::stod("0X1.1A62633145C07P-54"),DEC::def), DI<double>(1.57,1.58,DEC::def)), DI<double>(std::stod("0X1.921FB54442D17P+0"),std::stod("0X1.921FB54442D19P+0"),DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( cos_rev(DI<double>(std::stod("0X1.1A62633145C06P-54"),std::stod("0X1.1A62633145C07P-54"),DEC::def), DI<double>(1.57,1.58,DEC::def)) ), DEC::trv );
-    BOOST_CHECK_EQUAL( DI<double>::cos_rev(DI<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1"),DEC::dac), DI<double>(3.14,3.15,DEC::def)), DI<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d1ap+1"),DEC::trv) );
+    BOOST_CHECK_EQUAL( DI<double>::cos_rev(DI<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1"),DEC::dac), DI<double>(3.14,3.15,DEC::def)), DI<double>(std::stod("0x1.921fb52442d18p+1"),std::stod("0x1.921fb56442d19p+1"),DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( DI<double>::cos_rev(DI<double>(std::stod("-0X1P+0"),std::stod("-0X1.FFFFFFFFFFFFFP-1"),DEC::dac), DI<double>(3.14,3.15,DEC::def)) ), DEC::trv );
     BOOST_CHECK_EQUAL( DI<float>::cos_rev(DI<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53"),DEC::com), DI<double>(-INF_D,1.5,DEC::dac)), DI<float>(-INF_F,std::stof("-0X1.921FB4P+0"),DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( DI<float>::cos_rev(DI<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53"),DEC::com), DI<double>(-INF_D,1.5,DEC::dac)) ), DEC::trv );
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(integration_tan_rev_test)
     BOOST_CHECK_EQUAL( I<double>::tan_rev(I<double>(0.1,0.1)), I<double>(-INF_D, INF_D) );
     BOOST_CHECK_EQUAL( I<float>::tan_rev(I<double>(std::stod("0X1.1A62633145C06P-53"),std::stod("0X1.1A62633145C07P-53"))), I<float>(-INF_F, INF_F) );
 
-    BOOST_CHECK_EQUAL( tan_rev(I<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")), I<double>(-3.15,3.15)), I<double>(std::stod("-0X1.921FB54442D19P+1"),std::stod("0X1.921FB54442D1aP+1")) );
+    BOOST_CHECK_EQUAL( tan_rev(I<double>(std::stod("0X1.72CECE675D1FCP-52"),std::stod("0X1.72CECE675D1FDP-52")), I<double>(-3.15,3.15)), I<double>(std::stod("-0X1.921FB54442D18P+1"),std::stod("0X1.921FB54442D1aP+1")) );
     BOOST_CHECK_EQUAL( I<double>::tan_rev(I<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53")), I<double>(-1.5707965,INF_D)), I<double>(std::stod("-0x1.111858f8568f7p+0"),INF_D) );
     BOOST_CHECK_EQUAL( I<float>::tan_rev(I<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53")), I<double>(-1.5708,1.5708)), I<float>(std::stof("-0x1.921fb6p+0"),std::stof("0x1.921fb6p+0")) );
 
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(integration_tan_rev_test)
     BOOST_CHECK_EQUAL( DI<float>::tan_rev(DI<double>(-156.0,-12.0,DEC::com)), DI<float>(-INF_F, INF_F,DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( DI<float>::tan_rev(DI<double>(-156.0,-12.0,DEC::com)) ), DEC::trv );
 
-    BOOST_CHECK_EQUAL( tan_rev(DI<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53"),DEC::dac), DI<double>(-1.5708,1.5708,DEC::def)), DI<double>(std::stod("-0x1.921fb54442d1bp+0"),std::stod("0x1.921fb54442d19p+0"),DEC::trv) );
+    BOOST_CHECK_EQUAL( tan_rev(DI<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53"),DEC::dac), DI<double>(-1.5708,1.5708,DEC::def)), DI<double>(std::stod("-0x1.921fb54442d19p+0"),std::stod("0x1.921fb54442d19p+0"),DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( tan_rev(DI<double>(std::stod("0X1.D02967C31CDB4P+53"),std::stod("0X1.D02967C31CDB5P+53"),DEC::dac), DI<double>(-1.5708,1.5708,DEC::def)) ), DEC::trv );
     BOOST_CHECK_EQUAL( DI<double>::tan_rev(DI<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53"),DEC::def), DI<double>(-INF_D,1.5707965,DEC::def)), DI<double>(-INF_D,std::stod("0x1.111858f8568f7p+0"),DEC::trv) );
     BOOST_CHECK_EQUAL( decoration( DI<double>::tan_rev(DI<double>(std::stod("-0X1.D02967C31+53"),std::stod("0X1.D02967C31+53"),DEC::def), DI<double>(-INF_D,1.5707965,DEC::def)) ), DEC::trv );

--- a/test/p1788/util/test_mpfr_var.cpp
+++ b/test/p1788/util/test_mpfr_var.cpp
@@ -439,3 +439,127 @@ BOOST_AUTO_TEST_CASE(minimal_subnormalize_test)
     BOOST_CHECK(mpfr_equal_p(a(), x()));
     BOOST_CHECK(t1 == t2);
 }
+
+BOOST_AUTO_TEST_CASE(minimal_mpfr_root_si_test)
+{
+    mpfr_var<double>::setup();
+    mpfr_var<double> r;
+    mpfr_var<double> a;
+    mpfr_var<double> x;
+
+    a.set(0x1.7DE3A077D1568p-8, MPFR_RNDN);
+    x.set(0x1.a333333333334p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -2, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+    x.set(0x1.a333333333333p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -2, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+
+    a.set(0x1.D26DF4D8B1831p-12, MPFR_RNDN);
+    x.set(0x1.a333333333334p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -3, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+    x.set(0x1.a333333333333p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -3, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+
+    a.set(-0x1.D26DF4D8B1831p-12, MPFR_RNDN);
+    x.set(-0x1.a333333333333p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -3, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+    x.set(-0x1.a333333333334p+3, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_root_si(r(), a(), -3, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(r(), x()));
+}
+
+BOOST_AUTO_TEST_CASE(minimal_mpfr_quadrant)
+{
+    mpfr_var<double>::setup();
+    mpfr_var<double> a;
+    mpz_t k;
+    mpz_init(k);
+
+    a.set(214112296674652L, MPFR_RNDN);
+    p1788::util::mpfr_quadrant(k, a());
+    BOOST_CHECK(mpz_cmp_ui(k, 136308121570116L) == 0);
+
+    a.set(214112296674653L, MPFR_RNDN);
+    p1788::util::mpfr_quadrant(k, a());
+    BOOST_CHECK(mpz_cmp_ui(k, 136308121570117L) == 0);
+
+    mpz_clear(k);
+}
+
+BOOST_AUTO_TEST_CASE(minimal_mpfr_asin_npi)
+{
+    mpfr_var<double>::setup();
+    mpfr_var<double> a;
+    mpfr_var<double> x;
+    mpz_t npi;
+    mpz_init(npi);
+
+    mpz_set_ui(npi, 1); 
+    a.set(0x1.fffffffffffffp-1, MPFR_RNDN);
+    x.set(0x1.921fb58442d19p0, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_asin_npi(a(), a(), npi, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+    a.set(0x1.fffffffffffffp-1, MPFR_RNDN);
+    x.set(0x1.921fb58442d18p0, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_asin_npi(a(), a(), npi, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+
+    mpz_clear(npi);
+}
+
+BOOST_AUTO_TEST_CASE(minimal_mpfr_acos_npi)
+{
+    mpfr_var<double>::setup();
+    mpfr_var<double> a;
+    mpfr_var<double> x;
+    mpz_t npi;
+    mpz_init(npi);
+
+    mpz_set_ui(npi, 0); 
+    a.set(-1.0, MPFR_RNDN);
+    x.set(0x1.921fb54442d19p1, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_acos_npi(a(), a(), npi, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+    a.set(-1.0, MPFR_RNDN);
+    x.set(0x1.921fb54442d18p1, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_acos_npi(a(), a(), npi, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+
+    mpz_set_ui(npi, 1); 
+    a.set(-1.0, MPFR_RNDN);
+    x.set(0x1.921fb54442d19p1, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_acos_npi(a(), a(), npi, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+    a.set(-1.0, MPFR_RNDN);
+    x.set(0x1.921fb54442d18p1, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_acos_npi(a(), a(), npi, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+
+    mpz_clear(npi);
+}
+
+BOOST_AUTO_TEST_CASE(minimal_mpfr_atan_npi)
+{
+    mpfr_var<double>::setup();
+    mpfr_var<double> a;
+    mpfr_var<double> x;
+    mpz_t npi;
+    mpz_init(npi);
+
+    mpz_set_si(npi, -1); 
+    a.set(16331239353195368L, MPFR_RNDN);
+    x.set(-0x1.921fb54442d18p0, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_atan_npi(a(), a(), npi, MPFR_RNDU), 1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+    a.set(16331239353195368, MPFR_RNDN);
+    x.set(-0x1.921fb54442d19p0, MPFR_RNDN);
+    BOOST_CHECK_EQUAL(p1788::util::mpfr_atan_npi(a(), a(), npi, MPFR_RNDD), -1);
+    BOOST_CHECK(mpfr_equal_p(a(), x()));
+
+    mpz_clear(npi);
+}
+


### PR DESCRIPTION
Fix #20 for `pown_rev(c,x,p)` with positive p.
Use `util::mpfr_root_si` for implementation of `pown_rev` .

The function
`int utill::mpfr_root_si(mpfr_ptr rop, mpfr_srcptr op, long int k, mpfr_rnd_t);`
might be a prototype for future submission to MPFR.
It replaces methods
`mpfr_bin_ieee754_flavor::pown_rev_inf`
`mpfr_bin_ieee754_flavor::pown_rev_sup`
# 

Add mpfr extensions `mpfr_quadrant`, `mpfr_asin_npi`, `mpfr_acos_npi`, `mpfr_atan_npi` and tests for them.
# 

These extensions are used for the tightest operations `sinRev`, `cosRev`, `tanRev`.
